### PR TITLE
Replaced GuidConverter with inline calls to LogGuid

### DIFF
--- a/dds/DCPS/BitPubListenerImpl.cpp
+++ b/dds/DCPS/BitPubListenerImpl.cpp
@@ -58,11 +58,10 @@ void BitPubListenerImpl::on_data_available(DDS::DataReader_ptr reader)
           CORBA::Long const ownership_strength = data.ownership_strength.value;
           this->partipant_->update_ownership_strength(pub_id, ownership_strength);
           if (DCPS_debug_level > 4) {
-            GuidConverter writer_converter(pub_id);
             ACE_DEBUG((LM_DEBUG,
               ACE_TEXT("(%P|%t) BitPubListenerImpl::on_data_available: %X ")
               ACE_TEXT("reset ownership strength %d for writer %C.\n"),
-              this, ownership_strength, OPENDDS_STRING(writer_converter).c_str()));
+              this, ownership_strength, LogGuid(pub_id).c_str()));
           }
 #endif
         }

--- a/dds/DCPS/CoherentChangeControl.cpp
+++ b/dds/DCPS/CoherentChangeControl.cpp
@@ -109,16 +109,14 @@ std::ostream& operator<<(std::ostream& str, const CoherentChangeControl& value)
       << ", last_sample: " << value.coherent_samples_.last_sample_.getValue()
       << ", ";
   if (value.group_coherent_) {
-    GuidConverter converter(value.publisher_id_);
-    str << "publisher: " << std::dec << OPENDDS_STRING(converter).c_str() << ", ";
+    str << "publisher: " << std::dec << LogGuid(value.publisher_id_).c_str() << ", ";
     str << "group size: " << std::dec << value.group_coherent_samples_.size()
         << ", ";
     GroupCoherentSamples::const_iterator itEnd =
       value.group_coherent_samples_.end();
     for (GroupCoherentSamples::const_iterator it =
            value.group_coherent_samples_.begin(); it != itEnd; ++it) {
-      GuidConverter converter(it->first);
-      str << "writer: " << OPENDDS_STRING(converter).c_str() << ", "
+      str << "writer: " << LogGuid(it->first).c_str() << ", "
           << "num_samples: " << it->second.num_samples_ << ", "
           << "last_sample: " << it->second.last_sample_.getValue()  << std::endl;
     }

--- a/dds/DCPS/DataReaderImpl.cpp
+++ b/dds/DCPS/DataReaderImpl.cpp
@@ -225,12 +225,10 @@ DataReaderImpl::add_association(const RepoId& yourId,
     bool active)
 {
   if (DCPS_debug_level) {
-    GuidConverter reader_converter(yourId);
-    GuidConverter writer_converter(writer.writerId);
     ACE_DEBUG((LM_DEBUG, ACE_TEXT("(%P|%t) DataReaderImpl::add_association - ")
         ACE_TEXT("bit %d local %C remote %C\n"), is_bit_,
-        OPENDDS_STRING(reader_converter).c_str(),
-        OPENDDS_STRING(writer_converter).c_str()));
+        LogGuid(yourId).c_str(),
+        LogGuid(writer.writerId).c_str()));
   }
 
   if (get_deleted()) {
@@ -293,24 +291,21 @@ DataReaderImpl::add_association(const RepoId& yourId,
     }
 
     if (DCPS_debug_level > 4) {
-      GuidConverter converter(writer_id);
       ACE_DEBUG((LM_DEBUG,
           "(%P|%t) DataReaderImpl::add_association: "
           "inserted writer %C.return %d\n",
-          OPENDDS_STRING(converter).c_str(), bpair.second));
+          LogGuid(writer_id).c_str(), bpair.second));
 
       WriterMapType::iterator iter = writers_.find(writer_id);
       if (iter != writers_.end()) {
         // This may not be an error since it could happen that the sample
         // is delivered to the datareader after the write is dis-associated
         // with this datareader.
-        GuidConverter reader_converter(get_repo_id());
-        GuidConverter writer_converter(writer_id);
         ACE_DEBUG((LM_DEBUG,
             ACE_TEXT("(%P|%t) DataReaderImpl::add_association: ")
             ACE_TEXT("reader %C is associated with writer %C.\n"),
-            OPENDDS_STRING(reader_converter).c_str(),
-            OPENDDS_STRING(writer_converter).c_str()));
+            LogGuid(get_repo_id()).c_str(),
+            LogGuid(writer_id).c_str()));
       }
     }
   }
@@ -357,11 +352,10 @@ DataReaderImpl::transport_assoc_done(int flags, const RepoId& remote_id)
 {
   if (!(flags & ASSOC_OK)) {
     if (DCPS_debug_level) {
-      const GuidConverter conv(remote_id);
       ACE_ERROR((LM_ERROR,
           ACE_TEXT("(%P|%t) DataReaderImpl::transport_assoc_done: ")
           ACE_TEXT("ERROR: transport layer failed to associate %C\n"),
-          OPENDDS_STRING(conv).c_str()));
+          LogGuid(remote_id).c_str()));
     }
     return;
   }
@@ -373,11 +367,10 @@ DataReaderImpl::transport_assoc_done(int flags, const RepoId& remote_id)
     // LIVELINESS policy timers are managed here.
     if (!liveliness_lease_duration_.is_zero()) {
       if (DCPS_debug_level >= 5) {
-        GuidConverter converter(get_repo_id());
         ACE_DEBUG((LM_DEBUG,
             ACE_TEXT("(%P|%t) DataReaderImpl::transport_assoc_done: ")
             ACE_TEXT("starting/resetting liveliness timer for reader %C\n"),
-            OPENDDS_STRING(converter).c_str()));
+            LogGuid(get_repo_id()).c_str()));
       }
       // this call will start the timer if it is not already set
       liveliness_timer_->check_liveliness();
@@ -404,11 +397,10 @@ DataReaderImpl::transport_assoc_done(int flags, const RepoId& remote_id)
           RepoIdToHandleMap::value_type(remote_id, handle));
 
       if (DCPS_debug_level > 4) {
-        GuidConverter converter(remote_id);
         ACE_DEBUG((LM_DEBUG,
             ACE_TEXT("(%P|%t) DataReaderImpl::transport_assoc_done: ")
             ACE_TEXT("id_to_handle_map_[ %C] = 0x%x.\n"),
-            OPENDDS_STRING(converter).c_str(),
+            LogGuid(remote_id).c_str(),
             handle));
       }
 
@@ -478,14 +470,12 @@ DataReaderImpl::remove_associations(const WriterIdSeq& writers,
   }
 
   if (DCPS_debug_level >= 1) {
-    GuidConverter reader_converter(get_repo_id());
-    GuidConverter writer_converter(writers[0]);
     ACE_DEBUG((LM_DEBUG,
         ACE_TEXT("(%P|%t) DataReaderImpl::remove_associations: ")
         ACE_TEXT("bit %d local %C remote %C num remotes %d\n"),
         is_bit_,
-        OPENDDS_STRING(reader_converter).c_str(),
-        OPENDDS_STRING(writer_converter).c_str(),
+        LogGuid(get_repo_id()).c_str(),
+        LogGuid(writers[0]).c_str(),
         writers.length()));
   }
   if (!get_deleted()) {
@@ -520,14 +510,12 @@ DataReaderImpl::remove_associations_i(const WriterIdSeq& writers,
   }
 
   if (DCPS_debug_level >= 1) {
-    GuidConverter reader_converter(get_repo_id());
-    GuidConverter writer_converter(writers[0]);
     ACE_DEBUG((LM_DEBUG,
         ACE_TEXT("(%P|%t) DataReaderImpl::remove_associations_i: ")
         ACE_TEXT("bit %d local %C remote %C num remotes %d\n"),
         is_bit_,
-        OPENDDS_STRING(reader_converter).c_str(),
-        OPENDDS_STRING(writer_converter).c_str(),
+        LogGuid(get_repo_id()).c_str(),
+        LogGuid(writers[0]).c_str(),
         writers.length()));
   }
   DDS::InstanceHandleSeq handles;
@@ -566,11 +554,10 @@ DataReaderImpl::remove_associations_i(const WriterIdSeq& writers,
 
       if (this->writers_.erase(writer_id) == 0) {
         if (DCPS_debug_level >= 1) {
-          GuidConverter converter(writer_id);
           ACE_DEBUG((LM_DEBUG,
               ACE_TEXT("(%P|%t) DataReaderImpl::remove_associations_i: ")
               ACE_TEXT("the writer local %C was already removed.\n"),
-              OPENDDS_STRING(converter).c_str()));
+              LogGuid(writer_id).c_str()));
         }
 
       } else {
@@ -1372,13 +1359,11 @@ DataReaderImpl::writer_activity(const DataSampleHeader& header)
       // This may not be an error since it could happen that the sample
       // is delivered to the datareader after the write is dis-associated
       // with this datareader.
-      GuidConverter reader_converter(get_repo_id());
-      GuidConverter writer_converter(header.publication_id_);
       ACE_DEBUG((LM_DEBUG,
           ACE_TEXT("(%P|%t) DataReaderImpl::writer_activity: ")
           ACE_TEXT("reader %C is not associated with writer %C.\n"),
-          OPENDDS_STRING(reader_converter).c_str(),
-          OPENDDS_STRING(writer_converter).c_str()));
+          LogGuid(get_repo_id()).c_str(),
+          LogGuid(header.publication_id_).c_str()));
     }
   }
 
@@ -1412,11 +1397,10 @@ DataReaderImpl::data_received(const ReceivedDataSample& sample)
   if (get_deleted()) return;
 
   if (DCPS_debug_level > 9) {
-    GuidConverter converter(get_repo_id());
     ACE_DEBUG((LM_DEBUG,
         ACE_TEXT("(%P|%t) DataReaderImpl::data_received: ")
         ACE_TEXT("%C received sample: %C.\n"),
-        OPENDDS_STRING(converter).c_str(),
+        LogGuid(get_repo_id()).c_str(),
         to_string(sample.header_).c_str()));
   }
 
@@ -1459,14 +1443,11 @@ DataReaderImpl::data_received(const ReceivedDataSample& sample)
 
     // Per sample logging
     if (DCPS_debug_level >= 8) {
-      GuidConverter reader_converter(get_repo_id());
-      GuidConverter writer_converter(header.publication_id_);
-
       ACE_DEBUG((LM_DEBUG,
           ACE_TEXT("(%P|%t) DataReaderImpl::data_received: reader %C writer %C ")
           ACE_TEXT("instance %d is_new_instance %d filtered %d\n"),
-          OPENDDS_STRING(reader_converter).c_str(),
-          OPENDDS_STRING(writer_converter).c_str(),
+          LogGuid(get_repo_id()).c_str(),
+          LogGuid(header.publication_id_).c_str(),
           instance ? instance->instance_handle_ : 0,
           is_new_instance, filtered));
     }
@@ -1510,14 +1491,12 @@ DataReaderImpl::data_received(const ReceivedDataSample& sample)
           this->writers_.find(sample.header_.publication_id_);
 
       if (it == this->writers_.end()) {
-        GuidConverter sub_id(get_repo_id());
-        GuidConverter pub_id(sample.header_.publication_id_);
         ACE_DEBUG((LM_WARNING,
             ACE_TEXT("(%P|%t) WARNING: DataReaderImpl::data_received() - ")
             ACE_TEXT(" subscription %C failed to find ")
             ACE_TEXT(" publication data for %C!\n"),
-            OPENDDS_STRING(sub_id).c_str(),
-            OPENDDS_STRING(pub_id).c_str()));
+            LogGuid(get_repo_id()).c_str(),
+            LogGuid(sample.header_.publication_id_).c_str()));
         return;
       }
       else {
@@ -1535,13 +1514,11 @@ DataReaderImpl::data_received(const ReceivedDataSample& sample)
 
   case DATAWRITER_LIVELINESS: {
     if (DCPS_debug_level >= 4) {
-      GuidConverter reader_converter(get_repo_id());
-      GuidConverter writer_converter(sample.header_.publication_id_);
       ACE_DEBUG((LM_DEBUG,
                  ACE_TEXT("(%P|%t) DataReaderImpl::data_received: ")
                  ACE_TEXT("reader %C got datawriter liveliness from writer %C\n"),
-                 OPENDDS_STRING(reader_converter).c_str(),
-                 OPENDDS_STRING(writer_converter).c_str()));
+                 LogGuid(get_repo_id()).c_str(),
+                 LogGuid(sample.header_.publication_id_).c_str()));
     }
     this->writer_activity(sample.header_);
 
@@ -1676,11 +1653,10 @@ DataReaderImpl::data_received(const ReceivedDataSample& sample)
     guard.release();
     resume_sample_processing(sample.header_.publication_id_);
     if (DCPS_debug_level > 4) {
-      GuidConverter pub_id(sample.header_.publication_id_);
       ACE_DEBUG((
           LM_INFO,
           "(%P|%t) Resumed sample processing for durable writer %C\n",
-          OPENDDS_STRING(pub_id).c_str()));
+          LogGuid(sample.header_.publication_id_).c_str()));
     }
     break;
   }
@@ -1877,11 +1853,10 @@ DataReaderImpl::LivelinessTimer::check_liveliness_i(bool cancel,
 
   if (local_timer_id != -1 && cancel) {
     if (DCPS_debug_level >= 5) {
-      GuidConverter converter(data_reader->get_repo_id());
       ACE_DEBUG((LM_DEBUG,
                  ACE_TEXT("(%P|%t) DataReaderImpl::LivelinessTimer::check_liveliness_i: ")
                  ACE_TEXT(" canceling timer for reader %C.\n"),
-                 OPENDDS_STRING(converter).c_str()));
+                 LogGuid(data_reader->get_repo_id()).c_str()));
     }
 
     // called from add_associations and there is already a timer
@@ -1943,11 +1918,10 @@ DataReaderImpl::LivelinessTimer::check_liveliness_i(bool cancel,
   }
 
   if (DCPS_debug_level >= 5) {
-    GuidConverter converter(data_reader->get_repo_id());
     ACE_DEBUG((LM_DEBUG,
         ACE_TEXT("(%P|%t) DataReaderImpl::LivelinessTimer::check_liveliness_i: ")
         ACE_TEXT("reader %C has %d live writers; from_reactor=%d\n"),
-        OPENDDS_STRING(converter).c_str(),
+        LogGuid(data_reader->get_repo_id()).c_str(),
         alive_writers,
         !cancel));
   }
@@ -2056,13 +2030,11 @@ DataReaderImpl::writer_removed(WriterInfo& info)
   const PublicationId info_writer_id = info.writer_id();
 
   if (DCPS_debug_level >= 5) {
-    GuidConverter reader_converter(get_repo_id());
-    GuidConverter writer_converter(info_writer_id);
     ACE_DEBUG((LM_DEBUG,
         ACE_TEXT("(%P|%t) DataReaderImpl::writer_removed: ")
         ACE_TEXT("reader %C from writer %C.\n"),
-        OPENDDS_STRING(reader_converter).c_str(),
-        OPENDDS_STRING(writer_converter).c_str()));
+        LogGuid(get_repo_id()).c_str(),
+        LogGuid(info_writer_id).c_str()));
   }
 
 #ifndef OPENDDS_NO_OWNERSHIP_KIND_EXCLUSIVE
@@ -2108,12 +2080,10 @@ DataReaderImpl::writer_became_alive(WriterInfo& info, const MonotonicTimePoint& 
   const PublicationId info_writer_id = info.writer_id();
 
   if (DCPS_debug_level >= 5) {
-    GuidConverter reader_converter(get_repo_id());
-    GuidConverter writer_converter(info_writer_id);
     ACE_DEBUG((LM_DEBUG, ACE_TEXT("(%P|%t) DataReaderImpl::writer_became_alive: ")
                ACE_TEXT("reader %C from writer %C previous state %C.\n"),
-               OPENDDS_STRING(reader_converter).c_str(),
-               OPENDDS_STRING(writer_converter).c_str(),
+               LogGuid(get_repo_id()).c_str(),
+               LogGuid(info_writer_id).c_str(),
                info.get_state_str()));
   }
 
@@ -2180,12 +2150,10 @@ DataReaderImpl::writer_became_dead(WriterInfo& info)
   const PublicationId info_writer_id = info.writer_id();
 
   if (DCPS_debug_level >= 5) {
-    GuidConverter reader_converter(get_repo_id());
-    GuidConverter writer_converter(info_writer_id);
     ACE_DEBUG((LM_DEBUG, ACE_TEXT("(%P|%t) DataReaderImpl::writer_became_dead: ")
                ACE_TEXT("reader %C from writer %C previous state %C.\n"),
-               OPENDDS_STRING(reader_converter).c_str(),
-               OPENDDS_STRING(writer_converter).c_str(),
+               LogGuid(get_repo_id()).c_str(),
+               LogGuid(info_writer_id).c_str(),
                info.get_state_str()));
   }
 
@@ -2342,13 +2310,11 @@ void DataReaderImpl::process_latency(const ReceivedDataSample& sample)
     ///     association has been torn down).  We may want to promote this
     ///     to a warning if other conditions causing this symptom are
     ///     discovered.
-    GuidConverter reader_converter(get_repo_id());
-    GuidConverter writer_converter(sample.header_.publication_id_);
     ACE_DEBUG((LM_DEBUG,
         ACE_TEXT("(%P|%t) DataReaderImpl::process_latency() - ")
         ACE_TEXT("reader %C is not associated with writer %C (late sample?).\n"),
-        OPENDDS_STRING(reader_converter).c_str(),
-        OPENDDS_STRING(writer_converter).c_str()));
+        LogGuid(get_repo_id()).c_str(),
+        LogGuid(sample.header_.publication_id_).c_str()));
   }
 }
 
@@ -2577,7 +2543,7 @@ DataReaderImpl::lookup_instance_handles(const WriterIdSeq& ids,
 
     for (CORBA::ULong i = 0; i < num_wrts; ++i) {
       guids += separator;
-      guids += OPENDDS_STRING(GuidConverter(ids[i]));
+      guids += LogGuid(ids[i]).conv_;
       separator = ", ";
     }
 
@@ -2659,13 +2625,11 @@ DataReaderImpl::ownership_filter_instance(const SubscriptionInstance_rch& instan
         // This may not be an error since it could happen that the sample
         // is delivered to the datareader after the write is dis-associated
         // with this datareader.
-        GuidConverter reader_converter(get_repo_id());
-        GuidConverter writer_converter(pubid);
         ACE_DEBUG((LM_DEBUG,
                    ACE_TEXT("(%P|%t) DataReaderImpl::ownership_filter_instance: ")
                    ACE_TEXT("reader %C is not associated with writer %C.\n"),
-                   OPENDDS_STRING(reader_converter).c_str(),
-                   OPENDDS_STRING(writer_converter).c_str()));
+                   LogGuid(get_repo_id()).c_str(),
+                   LogGuid(pubid).c_str()));
       }
       return true;
     }
@@ -2686,30 +2650,24 @@ DataReaderImpl::ownership_filter_instance(const SubscriptionInstance_rch& instan
 
       if (! is_owner) {
         if (DCPS_debug_level >= 1) {
-          GuidConverter reader_converter(get_repo_id());
-          GuidConverter writer_converter(pubid);
-          GuidConverter owner_converter(instance->instance_state_->get_owner());
           ACE_DEBUG((LM_DEBUG,
                      ACE_TEXT("(%P|%t) DataReaderImpl::ownership_filter_instance: ")
                      ACE_TEXT("reader %C writer %C is not elected as owner %C\n"),
-                     OPENDDS_STRING(reader_converter).c_str(),
-                     OPENDDS_STRING(writer_converter).c_str(),
-                     OPENDDS_STRING(owner_converter).c_str()));
+                     LogGuid(get_repo_id()).c_str(),
+                     LogGuid(pubid).c_str(),
+                     LogGuid(instance->instance_state_->get_owner()).c_str()));
         }
         return true;
       }
     }
     else if (! (instance->instance_state_->get_owner() == pubid)) {
       if (DCPS_debug_level >= 1) {
-        GuidConverter reader_converter(get_repo_id());
-        GuidConverter writer_converter(pubid);
-        GuidConverter owner_converter(instance->instance_state_->get_owner());
         ACE_DEBUG((LM_DEBUG,
                    ACE_TEXT("(%P|%t) DataReaderImpl::ownership_filter_instance: ")
                    ACE_TEXT("reader %C writer %C is not owner %C\n"),
-                   OPENDDS_STRING(reader_converter).c_str(),
-                   OPENDDS_STRING(writer_converter).c_str(),
-                   OPENDDS_STRING(owner_converter).c_str()));
+                   LogGuid(get_repo_id()).c_str(),
+                   LogGuid(pubid).c_str(),
+                   LogGuid(instance->instance_state_->get_owner()).c_str()));
       }
       return true;
     }
@@ -2792,7 +2750,7 @@ void DataReaderImpl::notify_liveliness_change()
     ACE_Guard<ACE_Thread_Mutex> g(listener_mutex_);
     OPENDDS_STRING output_str;
     output_str += "subscription ";
-    output_str += OPENDDS_STRING(GuidConverter(get_repo_id()));
+    output_str += LogGuid(get_repo_id()).conv_;
     output_str += ", listener at: 0x";
     output_str += to_dds_string(this->listener_.in());
 
@@ -2801,7 +2759,7 @@ void DataReaderImpl::notify_liveliness_change()
          ++current) {
       const RepoId id = current->first;
       output_str += "\n\tNOTIFY: writer[ ";
-      output_str += OPENDDS_STRING(GuidConverter(id));
+      output_str += LogGuid(id).conv_;
       output_str += "] == ";
       output_str += current->second->get_state_str();
     }
@@ -2900,13 +2858,11 @@ DataReaderImpl::update_ownership_strength(const PublicationId& pub_id,
     if (iter->second->writer_id() == pub_id) {
       if (ownership_strength != iter->second->writer_qos_ownership_strength()) {
         if (DCPS_debug_level >= 1) {
-          GuidConverter reader_converter(get_repo_id());
-          GuidConverter writer_converter(pub_id);
           ACE_DEBUG((LM_DEBUG,
               ACE_TEXT("(%P|%t) DataReaderImpl::update_ownership_strength - ")
               ACE_TEXT("local %C update remote %C strength from %d to %d\n"),
-              OPENDDS_STRING(reader_converter).c_str(),
-              OPENDDS_STRING(writer_converter).c_str(),
+              LogGuid(get_repo_id()).c_str(),
+              LogGuid(pub_id).c_str(),
               iter->second->writer_qos_ownership_strength(), ownership_strength));
         }
         iter->second->writer_qos_ownership_strength(ownership_strength);
@@ -2959,15 +2915,12 @@ void DataReaderImpl::accept_coherent(const PublicationId& writer_id,
     const RepoId& publisher_id)
 {
   if (::OpenDDS::DCPS::DCPS_debug_level > 0) {
-    GuidConverter reader (get_repo_id());
-    GuidConverter writer (writer_id);
-    GuidConverter publisher (publisher_id);
     ACE_DEBUG((LM_DEBUG,
         ACE_TEXT("(%P|%t) DataReaderImpl::accept_coherent()")
         ACE_TEXT(" reader %C writer %C publisher %C\n"),
-        OPENDDS_STRING(reader).c_str(),
-        OPENDDS_STRING(writer).c_str(),
-        OPENDDS_STRING(publisher).c_str()));
+        LogGuid(get_repo_id()).c_str(),
+        LogGuid(writer_id).c_str(),
+        LogGuid(publisher_id).c_str()));
   }
   SubscriptionInstanceSet localsubs;
   {
@@ -2989,15 +2942,12 @@ void DataReaderImpl::reject_coherent(const PublicationId& writer_id,
     const RepoId& publisher_id)
 {
   if (::OpenDDS::DCPS::DCPS_debug_level > 0) {
-    GuidConverter reader (get_repo_id());
-    GuidConverter writer (writer_id);
-    GuidConverter publisher (publisher_id);
     ACE_DEBUG((LM_DEBUG,
         ACE_TEXT("(%P|%t) DataReaderImpl::reject_coherent()")
         ACE_TEXT(" reader %C writer %C publisher %C\n"),
-        OPENDDS_STRING(reader).c_str(),
-        OPENDDS_STRING(writer).c_str(),
-        OPENDDS_STRING(publisher).c_str()));
+        LogGuid(get_repo_id()).c_str(),
+        LogGuid(writer_id).c_str(),
+        LogGuid(publisher_id).c_str()));
   }
 
   SubscriptionInstanceSet localsubs;
@@ -3414,14 +3364,12 @@ void DataReaderImpl::accept_sample_processing(const SubscriptionInstance_rch& in
       }
     }
     else {
-      GuidConverter subscriptionBuffer(get_repo_id());
-      GuidConverter publicationBuffer(header.publication_id_);
       ACE_DEBUG((LM_WARNING,
         ACE_TEXT("(%P|%t) WARNING: DataReaderImpl::accept_sample_processing - ")
         ACE_TEXT("subscription %C failed to find ")
         ACE_TEXT("publication data for %C.\n"),
-        OPENDDS_STRING(subscriptionBuffer).c_str(),
-        OPENDDS_STRING(publicationBuffer).c_str()));
+        LogGuid(get_repo_id()).c_str(),
+        LogGuid(header.publication_id_).c_str()));
     }
   }
 
@@ -3499,11 +3447,9 @@ int EndHistoricSamplesMissedSweeper::handle_timeout(
     return 0;
 
   if (DCPS_debug_level >= 1) {
-    GuidConverter sub_repo(reader->get_repo_id());
-    GuidConverter pub_repo(pub_id);
     ACE_DEBUG((LM_INFO, "(%P|%t) EndHistoricSamplesMissedSweeper::handle_timeout reader: %C waiting on writer: %C\n",
-               OPENDDS_STRING(sub_repo).c_str(),
-               OPENDDS_STRING(pub_repo).c_str()));
+               LogGuid(reader->get_repo_id()).c_str(),
+               LogGuid(pub_id).c_str()));
   }
 
   reader->resume_sample_processing(pub_id);

--- a/dds/DCPS/DataReaderImpl_T.h
+++ b/dds/DCPS/DataReaderImpl_T.h
@@ -1433,10 +1433,9 @@ DDS::ReturnCode_t read_instance_i(MessageSequenceType& received_data,
       msg += state_obj->instance_state_string();
       msg += " while the validity mask is " + InstanceState::instance_state_mask_string(instance_states);
     }
-    const GuidConverter conv(get_repo_id());
     ACE_DEBUG((LM_DEBUG, ACE_TEXT("(%P|%t) DataReaderImpl_T::read_instance_i: ")
                ACE_TEXT("will return no data reading sub %C because:\n  %C\n"),
-               OPENDDS_STRING(conv).c_str(), msg.c_str()));
+               LogGuid(get_repo_id()).c_str(), msg.c_str()));
   }
 
   results.copy_to_user();

--- a/dds/DCPS/DataSampleHeader.cpp
+++ b/dds/DCPS/DataSampleHeader.cpp
@@ -583,10 +583,10 @@ OPENDDS_STRING to_string(const DataSampleHeader& value)
       ret += ", ";
     }
 
-    ret += "Publication: " + OPENDDS_STRING(GuidConverter(value.publication_id_));
+    ret += "Publication: " + LogGuid(value.publication_id_).conv_;
 #ifndef OPENDDS_NO_OBJECT_MODEL_PROFILE
     if (value.group_coherent_) {
-      ret += ", Publisher: " + OPENDDS_STRING(GuidConverter(value.publisher_id_));
+      ret += ", Publisher: " + LogGuid(value.publisher_id_).conv_;
     }
 #endif
 
@@ -596,7 +596,7 @@ OPENDDS_STRING to_string(const DataSampleHeader& value)
       ret += to_dds_string(len);
       ret += "): [";
       for (CORBA::ULong i(0); i < len; ++i) {
-        ret += OPENDDS_STRING(GuidConverter(value.content_filter_entries_[i])) + ' ';
+        ret += LogGuid(value.content_filter_entries_[i]).conv_ + ' ';
       }
       ret += ']';
     }

--- a/dds/DCPS/DataWriterImpl.cpp
+++ b/dds/DCPS/DataWriterImpl.cpp
@@ -205,12 +205,10 @@ DataWriterImpl::add_association(const RepoId& yourId,
   DBG_ENTRY_LVL("DataWriterImpl", "add_association", 6);
 
   if (DCPS_debug_level) {
-    GuidConverter writer_converter(yourId);
-    GuidConverter reader_converter(reader.readerId);
     ACE_DEBUG((LM_DEBUG, ACE_TEXT("(%P|%t) DataWriterImpl::add_association - ")
                ACE_TEXT("bit %d local %C remote %C\n"), is_bit_,
-               OPENDDS_STRING(writer_converter).c_str(),
-               OPENDDS_STRING(reader_converter).c_str()));
+               LogGuid(yourId).c_str(),
+               LogGuid(reader.readerId).c_str()));
   }
 
   if (get_deleted()) {
@@ -235,11 +233,10 @@ DataWriterImpl::add_association(const RepoId& yourId,
   }
 
   if (DCPS_debug_level > 4) {
-    GuidConverter converter(get_repo_id());
     ACE_DEBUG((LM_DEBUG,
                ACE_TEXT("(%P|%t) DataWriterImpl::add_association(): ")
                ACE_TEXT("adding subscription to publication %C with priority %d.\n"),
-               OPENDDS_STRING(converter).c_str(),
+               LogGuid(get_repo_id()).c_str(),
                qos_.transport_priority.value));
   }
 
@@ -276,11 +273,10 @@ DataWriterImpl::transport_assoc_done(int flags, const RepoId& remote_id)
 
   if (!(flags & ASSOC_OK)) {
     if (DCPS_debug_level) {
-      const GuidConverter conv(remote_id);
       ACE_ERROR((LM_ERROR,
                  ACE_TEXT("(%P|%t) DataWriterImpl::transport_assoc_done: ")
                  ACE_TEXT("ERROR: transport layer failed to associate %C\n"),
-                 OPENDDS_STRING(conv).c_str()));
+                 LogGuid(remote_id).c_str()));
     }
 
     return;
@@ -289,26 +285,22 @@ DataWriterImpl::transport_assoc_done(int flags, const RepoId& remote_id)
   ACE_Guard<ACE_Recursive_Thread_Mutex> guard(lock_);
 
   if (DCPS_debug_level) {
-    const GuidConverter writer_conv(publication_id_);
-    const GuidConverter conv(remote_id);
     ACE_DEBUG((LM_INFO,
                ACE_TEXT("(%P|%t) DataWriterImpl::transport_assoc_done: ")
                ACE_TEXT("writer %C succeeded in associating with reader %C\n"),
-               OPENDDS_STRING(writer_conv).c_str(),
-               OPENDDS_STRING(conv).c_str()));
+               LogGuid(publication_id_).c_str(),
+               LogGuid(remote_id).c_str()));
   }
 
   if (flags & ASSOC_ACTIVE) {
 
     // Have we already received an association_complete() callback?
     if (DCPS_debug_level) {
-      const GuidConverter writer_conv(publication_id_);
-      const GuidConverter converter(remote_id);
       ACE_DEBUG((LM_DEBUG,
                  ACE_TEXT("(%P|%t) DataWriterImpl::transport_assoc_done: ")
                  ACE_TEXT("writer %C reader %C calling association_complete_i\n"),
-                 OPENDDS_STRING(writer_conv).c_str(),
-                 OPENDDS_STRING(converter).c_str()));
+                 LogGuid(publication_id_).c_str(),
+                 LogGuid(remote_id).c_str()));
     }
     association_complete_i(remote_id);
 
@@ -316,11 +308,10 @@ DataWriterImpl::transport_assoc_done(int flags, const RepoId& remote_id)
     // In the current implementation, DataWriter is always active, so this
     // code will not be applicable.
     if (DCPS_debug_level) {
-      const GuidConverter conv(publication_id_);
       ACE_ERROR((LM_ERROR,
                  ACE_TEXT("(%P|%t) DataWriterImpl::transport_assoc_done: ")
                  ACE_TEXT("ERROR: DataWriter (%C) should always be active in current implementation\n"),
-                 OPENDDS_STRING(conv).c_str()));
+                 LogGuid(publication_id_).c_str()));
     }
   }
 }
@@ -430,20 +421,18 @@ DataWriterImpl::association_complete_i(const RepoId& remote_id)
       ACE_GUARD(ACE_Recursive_Thread_Mutex, guard, this->lock_);
 
       if (OpenDDS::DCPS::bind(id_to_handle_map_, remote_id, handle) != 0) {
-        GuidConverter converter(remote_id);
         ACE_DEBUG((LM_WARNING,
                    ACE_TEXT("(%P|%t) WARNING: DataWriterImpl::association_complete_i: ")
                    ACE_TEXT("id_to_handle_map_%C = 0x%x failed.\n"),
-                   OPENDDS_STRING(converter).c_str(),
+                   LogGuid(remote_id).c_str(),
                    handle));
         return;
 
       } else if (DCPS_debug_level > 4) {
-        GuidConverter converter(remote_id);
         ACE_DEBUG((LM_DEBUG,
                    ACE_TEXT("(%P|%t) DataWriterImpl::association_complete_i: ")
                    ACE_TEXT("id_to_handle_map_%C = 0x%x.\n"),
-                   OPENDDS_STRING(converter).c_str(),
+                   LogGuid(remote_id).c_str(),
                    handle));
       }
 
@@ -567,14 +556,12 @@ DataWriterImpl::remove_associations(const ReaderIdSeq & readers,
   }
 
   if (DCPS_debug_level >= 1) {
-    GuidConverter writer_converter(publication_id_);
-    GuidConverter reader_converter(readers[0]);
     ACE_DEBUG((LM_DEBUG,
                ACE_TEXT("(%P|%t) DataWriterImpl::remove_associations: ")
                ACE_TEXT("bit %d local %C remote %C num remotes %d\n"),
                is_bit_,
-               OPENDDS_STRING(writer_converter).c_str(),
-               OPENDDS_STRING(reader_converter).c_str(),
+               LogGuid(publication_id_).c_str(),
+               LogGuid(readers[0]).c_str(),
                readers.length()));
   }
 
@@ -908,11 +895,10 @@ DataWriterImpl::update_subscription_params(const RepoId& readerId,
 
   } else if (DCPS_debug_level > 4 &&
              TheServiceParticipant->publisher_content_filter()) {
-    GuidConverter pubConv(this->publication_id_), subConv(readerId);
     ACE_DEBUG((LM_WARNING,
                ACE_TEXT("(%P|%t) WARNING: DataWriterImpl::update_subscription_params()")
                ACE_TEXT(" - writer: %C has no info about reader: %C\n"),
-               OPENDDS_STRING(pubConv).c_str(), OPENDDS_STRING(subConv).c_str()));
+               LogGuid(this->publication_id_).c_str(), LogGuid(readerId).c_str()));
   }
 
 #endif
@@ -2155,11 +2141,10 @@ DataWriterImpl::create_control_message(MessageId message_id,
     }
   }
   if (DCPS_debug_level >= 4) {
-    const GuidConverter converter(publication_id_);
     ACE_DEBUG((LM_DEBUG,
                ACE_TEXT("(%P|%t) DataWriterImpl::create_control_message: ")
                ACE_TEXT("from publication %C sending control sample: %C .\n"),
-               OPENDDS_STRING(converter).c_str(),
+               LogGuid(publication_id_).c_str(),
                to_string(header_data).c_str()));
   }
   return message;
@@ -2240,11 +2225,10 @@ DataWriterImpl::create_sample_data_message(Message_Block_Ptr data,
   message.reset(tmp_message);
   *message << header_data;
   if (DCPS_debug_level >= 4) {
-    const GuidConverter converter(publication_id_);
     ACE_DEBUG((LM_DEBUG,
                ACE_TEXT("(%P|%t) DataWriterImpl::create_sample_data_message: ")
                ACE_TEXT("from publication %C sending data sample: %C .\n"),
-               OPENDDS_STRING(converter).c_str(),
+               LogGuid(publication_id_).c_str(),
                to_string(header_data).c_str()));
   }
   return DDS::RETCODE_OK;
@@ -2256,14 +2240,12 @@ DataWriterImpl::data_delivered(const DataSampleElement* sample)
   DBG_ENTRY_LVL("DataWriterImpl","data_delivered",6);
 
   if (!(sample->get_pub_id() == this->publication_id_)) {
-    GuidConverter sample_converter(sample->get_pub_id());
-    GuidConverter writer_converter(publication_id_);
     ACE_ERROR((LM_ERROR,
                ACE_TEXT("(%P|%t) ERROR: DataWriterImpl::data_delivered: ")
                ACE_TEXT("The publication id %C from delivered element ")
                ACE_TEXT("does not match the datawriter's id %C\n"),
-               OPENDDS_STRING(sample_converter).c_str(),
-               OPENDDS_STRING(writer_converter).c_str()));
+               LogGuid(sample->get_pub_id()).c_str(),
+               LogGuid(publication_id_).c_str()));
     return;
   }
   //provided for statistics tracking in tests
@@ -2702,7 +2684,7 @@ DataWriterImpl::lookup_instance_handles(const ReaderIdSeq& ids,
     OPENDDS_STRING buffer;
 
     for (CORBA::ULong i = 0; i < num_rds; ++i) {
-      buffer += separator + OPENDDS_STRING(GuidConverter(ids[i]));
+      buffer += separator + LogGuid(ids[i]).conv_;
       separator = ", ";
     }
 

--- a/dds/DCPS/DomainParticipantFactoryImpl.cpp
+++ b/dds/DCPS/DomainParticipantFactoryImpl.cpp
@@ -179,14 +179,13 @@ DomainParticipantFactoryImpl::delete_participant(
     DPMap::iterator pos = participants_.find(domain_id);
     if (pos == participants_.end()) {
       if (DCPS_debug_level > 0) {
-        GuidConverter converter(dp_id);
         ACE_ERROR((LM_ERROR,
                    ACE_TEXT("(%P|%t) ERROR: ")
                    ACE_TEXT("DomainParticipantFactoryImpl::delete_participant: ")
                    ACE_TEXT("%p domain_id=%d dp_id=%C.\n"),
                    ACE_TEXT("find"),
                    domain_id,
-                   OPENDDS_STRING(converter).c_str()));
+                   LogGuid(dp_id).c_str()));
       }
       return DDS::RETCODE_ERROR;
     }

--- a/dds/DCPS/DomainParticipantImpl.cpp
+++ b/dds/DCPS/DomainParticipantImpl.cpp
@@ -1251,11 +1251,10 @@ DomainParticipantImpl::ignore_participant(
   }
 
   if (DCPS_debug_level >= 4) {
-    GuidConverter converter(dp_id_);
     ACE_DEBUG((LM_DEBUG,
                ACE_TEXT("(%P|%t) DomainParticipantImpl::ignore_participant: ")
                ACE_TEXT("%C ignoring handle %x.\n"),
-               OPENDDS_STRING(converter).c_str(),
+               LogGuid(dp_id_).c_str(),
                handle));
   }
 
@@ -1273,11 +1272,10 @@ DomainParticipantImpl::ignore_participant(
 
 
   if (DCPS_debug_level >= 4) {
-    GuidConverter converter(dp_id_);
     ACE_DEBUG((LM_DEBUG,
                ACE_TEXT("(%P|%t) DomainParticipantImpl::ignore_participant: ")
                ACE_TEXT("%C repo call returned.\n"),
-               OPENDDS_STRING(converter).c_str()));
+               LogGuid(dp_id_).c_str()));
   }
 
   return DDS::RETCODE_OK;
@@ -1313,11 +1311,10 @@ DomainParticipantImpl::ignore_topic(
   }
 
   if (DCPS_debug_level >= 4) {
-    GuidConverter converter(dp_id_);
     ACE_DEBUG((LM_DEBUG,
                ACE_TEXT("(%P|%t) DomainParticipantImpl::ignore_topic: ")
                ACE_TEXT("%C ignoring handle %x.\n"),
-               OPENDDS_STRING(converter).c_str(),
+               LogGuid(dp_id_).c_str(),
                handle));
   }
 
@@ -1355,11 +1352,10 @@ DomainParticipantImpl::ignore_publication(
   }
 
   if (DCPS_debug_level >= 4) {
-    GuidConverter converter(dp_id_);
     ACE_DEBUG((LM_DEBUG,
                ACE_TEXT("(%P|%t) DomainParticipantImpl::ignore_publication: ")
                ACE_TEXT("%C ignoring handle %x.\n"),
-               OPENDDS_STRING(converter).c_str(),
+               LogGuid(dp_id_).c_str(),
                handle));
   }
 
@@ -1399,11 +1395,10 @@ DomainParticipantImpl::ignore_subscription(
   }
 
   if (DCPS_debug_level >= 4) {
-    GuidConverter converter(dp_id_);
     ACE_DEBUG((LM_DEBUG,
                ACE_TEXT("(%P|%t) DomainParticipantImpl::ignore_subscription: ")
                ACE_TEXT("%C ignoring handle %d.\n"),
-               OPENDDS_STRING(converter).c_str(),
+               LogGuid(dp_id_).c_str(),
                handle));
   }
 
@@ -1865,7 +1860,7 @@ DomainParticipantImpl::enable()
   if (DCPS_debug_level > 1) {
     ACE_DEBUG((LM_DEBUG, ACE_TEXT("(%P|%t) DomainParticipantImpl::enable: ")
                ACE_TEXT("enabled participant %C in domain %d\n"),
-               OPENDDS_STRING(GuidConverter(dp_id_)).c_str(), domain_id_));
+               LogGuid(dp_id_).c_str(), domain_id_));
   }
 
   if (ret == DDS::RETCODE_OK && !TheTransientKludge->is_enabled()) {

--- a/dds/DCPS/InstanceState.cpp
+++ b/dds/DCPS/InstanceState.cpp
@@ -150,9 +150,8 @@ bool InstanceState::dispose_was_received(const PublicationId& writer_id)
 bool InstanceState::unregister_was_received(const PublicationId& writer_id)
 {
   if (DCPS_debug_level > 1) {
-    GuidConverter conv(writer_id);
     ACE_DEBUG((LM_DEBUG, ACE_TEXT("(%P|%t) InstanceState::unregister_was_received on %C\n"),
-      OPENDDS_STRING(conv).c_str()
+      LogGuid(writer_id).c_str()
     ));
   }
 

--- a/dds/DCPS/OwnershipManager.cpp
+++ b/dds/DCPS/OwnershipManager.cpp
@@ -390,12 +390,11 @@ OwnershipManager::broadcast_new_owner(const DDS::InstanceHandle_t& instance_hand
     // This may not be an error since it could happen that the sample
     // is delivered to the datareader after the write is dis-associated
     // with this datareader.
-    GuidConverter writer_converter(owner);
     ACE_DEBUG((LM_DEBUG,
                ACE_TEXT("(%P|%t) OwnershipManager::broadcast_new_owner: ")
                ACE_TEXT("owner writer %C, instance handle %d strength %d num ")
                ACE_TEXT("of candidates %d\n"),
-               OPENDDS_STRING(writer_converter).c_str(), instance_handle,
+               LogGuid(owner).c_str(), instance_handle,
                infos.owner_.ownership_strength_,
                (int)infos.candidates_.size()));
   }

--- a/dds/DCPS/PublisherImpl.cpp
+++ b/dds/DCPS/PublisherImpl.cpp
@@ -194,13 +194,11 @@ PublisherImpl::delete_datawriter(DDS::DataWriter_ptr a_datawriter)
 
     if (dw_publisher.in() != this) {
       if (DCPS_debug_level > 0) {
-        RepoId id = dw_servant->get_repo_id();
-        GuidConverter converter(id);
         ACE_ERROR((LM_ERROR,
             ACE_TEXT("(%P|%t) PublisherImpl::delete_datawriter: ")
             ACE_TEXT("the data writer %C doesn't ")
             ACE_TEXT("belong to this subscriber\n"),
-            OPENDDS_STRING(converter).c_str()));
+            LogGuid(dw_servant->get_repo_id()).c_str()));
       }
       return DDS::RETCODE_PRECONDITION_NOT_MET;
     }
@@ -228,12 +226,11 @@ PublisherImpl::delete_datawriter(DDS::DataWriter_ptr a_datawriter)
 
     if (it == publication_map_.end()) {
       if (DCPS_debug_level > 0) {
-        GuidConverter converter(publication_id);
         ACE_ERROR((LM_ERROR,
             ACE_TEXT("(%P|%t) ERROR: ")
             ACE_TEXT("PublisherImpl::delete_datawriter, ")
             ACE_TEXT("datawriter %C not found.\n"),
-            OPENDDS_STRING(converter).c_str()));
+            LogGuid(publication_id).c_str()));
       }
       return DDS::RETCODE_ERROR;
     }
@@ -407,14 +404,13 @@ DDS::ReturnCode_t PublisherImpl::delete_contained_entities()
 
     if (ret != DDS::RETCODE_OK) {
       if (DCPS_debug_level > 0) {
-        GuidConverter converter(pub_id);
         ACE_ERROR((LM_ERROR,
             ACE_TEXT("(%P|%t) ERROR: ")
             ACE_TEXT("PublisherImpl::")
             ACE_TEXT("delete_contained_entities: ")
             ACE_TEXT("failed to delete ")
             ACE_TEXT("datawriter %C.\n"),
-            OPENDDS_STRING(converter).c_str()));
+            LogGuid(pub_id).c_str()));
       }
       return ret;
     }
@@ -460,13 +456,12 @@ PublisherImpl::set_qos(const DDS::PublisherQos & qos)
 
           if (!pair.second) {
             if (DCPS_debug_level > 0) {
-              GuidConverter converter(id);
               ACE_ERROR((LM_ERROR,
                   ACE_TEXT("(%P|%t) ")
                   ACE_TEXT("PublisherImpl::set_qos: ")
                   ACE_TEXT("insert id %C to DwIdToQosMap ")
                   ACE_TEXT("failed.\n"),
-                  OPENDDS_STRING(converter).c_str()));
+                  LogGuid(id).c_str()));
             }
             return DDS::RETCODE_ERROR;
           }
@@ -923,12 +918,11 @@ PublisherImpl::writer_enabled(const char*     topic_name,
 
   if (!pair.second) {
     if (DCPS_debug_level > 0) {
-      GuidConverter converter(publication_id);
       ACE_ERROR((LM_ERROR,
           ACE_TEXT("(%P|%t) ERROR: ")
           ACE_TEXT("PublisherImpl::writer_enabled: ")
           ACE_TEXT("insert publication %C failed.\n"),
-          OPENDDS_STRING(converter).c_str()));
+          LogGuid(publication_id).c_str()));
     }
     return DDS::RETCODE_ERROR;
   }

--- a/dds/DCPS/RecorderImpl.cpp
+++ b/dds/DCPS/RecorderImpl.cpp
@@ -420,11 +420,10 @@ RecorderImpl::add_association(const RepoId&            yourId,
         RepoIdToHandleMap::value_type(writer.writerId, handle));
 
       if (DCPS_debug_level > 4) {
-        GuidConverter converter(writer.writerId);
         ACE_DEBUG((LM_DEBUG,
                    ACE_TEXT("(%P|%t) RecorderImpl::add_association: ")
                    ACE_TEXT("id_to_handle_map_[ %C] = 0x%x.\n"),
-                   OPENDDS_STRING(converter).c_str(),
+                   LogGuid(writer.writerId).c_str(),
                    handle));
       }
 
@@ -509,14 +508,12 @@ RecorderImpl::remove_associations_i(const WriterIdSeq& writers,
   }
 
   if (DCPS_debug_level >= 4) {
-    GuidConverter reader_converter(subscription_id_);
-    GuidConverter writer_converter(writers[0]);
     ACE_DEBUG((LM_DEBUG,
                ACE_TEXT("(%P|%t) RecorderImpl::remove_associations_i: ")
                ACE_TEXT("bit %d local %C remote %C num remotes %d\n"),
                is_bit_,
-               OPENDDS_STRING(reader_converter).c_str(),
-               OPENDDS_STRING(writer_converter).c_str(),
+               LogGuid(subscription_id_).c_str(),
+               LogGuid(writers[0]).c_str(),
                writers.length()));
   }
   DDS::InstanceHandleSeq handles;
@@ -556,11 +553,10 @@ RecorderImpl::remove_associations_i(const WriterIdSeq& writers,
 
       if (this->writers_.erase(writer_id) == 0) {
         if (DCPS_debug_level >= 4) {
-          GuidConverter converter(writer_id);
           ACE_DEBUG((LM_DEBUG,
                      ACE_TEXT("(%P|%t) RecorderImpl::remove_associations_i: ")
                      ACE_TEXT("the writer local %C was already removed.\n"),
-                     OPENDDS_STRING(converter).c_str()));
+                     LogGuid(writer_id).c_str()));
         }
 
       } else {
@@ -843,7 +839,7 @@ RecorderImpl::lookup_instance_handles(const WriterIdSeq&       ids,
     OPENDDS_STRING buffer;
 
     for (CORBA::ULong i = 0; i < num_wrts; ++i) {
-      buffer += separator + OPENDDS_STRING(GuidConverter(ids[i]));
+      buffer += separator + LogGuid(ids[i]).conv_;
       separator = ", ";
     }
 

--- a/dds/DCPS/ReplayerImpl.cpp
+++ b/dds/DCPS/ReplayerImpl.cpp
@@ -405,14 +405,12 @@ ReplayerImpl::add_association(const RepoId&            yourId,
   DBG_ENTRY_LVL("ReplayerImpl", "add_association", 6);
 
   if (DCPS_debug_level >= 1) {
-    GuidConverter writer_converter(yourId);
-    GuidConverter reader_converter(reader.readerId);
     ACE_DEBUG((LM_DEBUG,
                ACE_TEXT("(%P|%t) ReplayerImpl::add_association - ")
                ACE_TEXT("bit %d local %C remote %C\n"),
                is_bit_,
-               OPENDDS_STRING(writer_converter).c_str(),
-               OPENDDS_STRING(reader_converter).c_str()));
+               LogGuid(yourId).c_str(),
+               LogGuid(reader.readerId).c_str()));
   }
 
   // if (entity_deleted_ == true) {
@@ -437,11 +435,10 @@ ReplayerImpl::add_association(const RepoId&            yourId,
   }
 
   if (DCPS_debug_level > 4) {
-    GuidConverter converter(publication_id_);
     ACE_DEBUG((LM_DEBUG,
                ACE_TEXT("(%P|%t) ReplayerImpl::add_association(): ")
                ACE_TEXT("adding subscription to publication %C with priority %d.\n"),
-               OPENDDS_STRING(converter).c_str(),
+               LogGuid(publication_id_).c_str(),
                qos_.transport_priority.value));
   }
 
@@ -498,11 +495,10 @@ ReplayerImpl::association_complete_i(const RepoId& remote_id)
   {
     ACE_GUARD(ACE_Recursive_Thread_Mutex, guard, this->lock_);
     if (OpenDDS::DCPS::insert(readers_, remote_id) == -1) {
-      GuidConverter converter(remote_id);
       ACE_ERROR((LM_ERROR,
                  ACE_TEXT("(%P|%t) ERROR: ReplayerImpl::association_complete_i: ")
                  ACE_TEXT("insert %C from pending failed.\n"),
-                 OPENDDS_STRING(converter).c_str()));
+                 LogGuid(remote_id).c_str()));
     }
     // RepoIdToReaderInfoMap::const_iterator it = reader_info_.find(remote_id);
     // if (it != reader_info_.end()) {
@@ -525,20 +521,18 @@ ReplayerImpl::association_complete_i(const RepoId& remote_id)
       ++publication_match_status_.current_count_change;
 
       if (OpenDDS::DCPS::bind(id_to_handle_map_, remote_id, handle) != 0) {
-        GuidConverter converter(remote_id);
         ACE_DEBUG((LM_WARNING,
                    ACE_TEXT("(%P|%t) ERROR: ReplayerImpl::association_complete_i: ")
                    ACE_TEXT("id_to_handle_map_%C = 0x%x failed.\n"),
-                   OPENDDS_STRING(converter).c_str(),
+                   LogGuid(remote_id).c_str(),
                    handle));
         return;
 
       } else if (DCPS_debug_level > 4) {
-        GuidConverter converter(remote_id);
         ACE_DEBUG((LM_DEBUG,
                    ACE_TEXT("(%P|%t) ReplayerImpl::association_complete_i: ")
                    ACE_TEXT("id_to_handle_map_%C = 0x%x.\n"),
-                   OPENDDS_STRING(converter).c_str(),
+                   LogGuid(remote_id).c_str(),
                    handle));
       }
 
@@ -566,14 +560,12 @@ ReplayerImpl::remove_associations(const ReaderIdSeq & readers,
                                   CORBA::Boolean      notify_lost)
 {
   if (DCPS_debug_level >= 1) {
-    GuidConverter writer_converter(publication_id_);
-    GuidConverter reader_converter(readers[0]);
     ACE_DEBUG((LM_DEBUG,
                ACE_TEXT("(%P|%t) ReplayerImpl::remove_associations: ")
                ACE_TEXT("bit %d local %C remote %C num remotes %d\n"),
                is_bit_,
-               OPENDDS_STRING(writer_converter).c_str(),
-               OPENDDS_STRING(reader_converter).c_str(),
+               LogGuid(publication_id_).c_str(),
+               LogGuid(readers[0]).c_str(),
                readers.length()));
   }
 
@@ -791,14 +783,12 @@ ReplayerImpl::data_delivered(const DataSampleElement* sample)
 {
   DBG_ENTRY_LVL("ReplayerImpl","data_delivered",6);
   if (!(sample->get_pub_id() == this->publication_id_)) {
-    GuidConverter sample_converter(sample->get_pub_id());
-    GuidConverter writer_converter(publication_id_);
     ACE_ERROR((LM_ERROR,
                ACE_TEXT("(%P|%t) ERROR: ReplayerImpl::data_delivered: ")
                ACE_TEXT(" The publication id %C from delivered element ")
                ACE_TEXT("does not match the datawriter's id %C\n"),
-               OPENDDS_STRING(sample_converter).c_str(),
-               OPENDDS_STRING(writer_converter).c_str()));
+               LogGuid(sample->get_pub_id()).c_str(),
+               LogGuid(publication_id_).c_str()));
     return;
   }
   DataSampleElement* elem = const_cast<DataSampleElement*>(sample);
@@ -1022,7 +1012,7 @@ ReplayerImpl::lookup_instance_handles(const ReaderIdSeq&       ids,
     OPENDDS_STRING buffer;
 
     for (CORBA::ULong i = 0; i < num_rds; ++i) {
-      buffer += separator + OPENDDS_STRING(GuidConverter(ids[i]));
+      buffer += separator + LogGuid(ids[i]).conv_;
       separator = ", ";
     }
 

--- a/dds/DCPS/Service_Participant.cpp
+++ b/dds/DCPS/Service_Participant.cpp
@@ -1205,11 +1205,10 @@ Service_Participant::set_repo_domain(const DDS::DomainId_t domain,
               repoList.push_back(std::make_pair(disc_iter->second, id));
 
               if (DCPS_debug_level > 0) {
-                GuidConverter converter(id);
                 ACE_DEBUG((LM_DEBUG,
                            ACE_TEXT("(%P|%t) Service_Participant::set_repo_domain: ")
                            ACE_TEXT("participant %C attached to Repo[ %C].\n"),
-                           OPENDDS_STRING(converter).c_str(),
+                           LogGuid(id).c_str(),
                            key.c_str()));
               }
 
@@ -1227,12 +1226,11 @@ Service_Participant::set_repo_domain(const DDS::DomainId_t domain,
   // Make all of the remote calls after releasing the lock.
   for (unsigned int index = 0; index < repoList.size(); ++index) {
     if (DCPS_debug_level > 0) {
-      GuidConverter converter(repoList[ index].second);
       ACE_DEBUG((LM_DEBUG,
                  ACE_TEXT("(%P|%t) Service_Participant::set_repo_domain: ")
                  ACE_TEXT("(%d of %d) attaching domain %d participant %C to Repo[ %C].\n"),
                  (1+index), repoList.size(), domain,
-                 OPENDDS_STRING(converter).c_str(),
+                 LogGuid(repoList[ index].second).c_str(),
                  key.c_str()));
     }
 

--- a/dds/DCPS/StaticDiscovery.cpp
+++ b/dds/DCPS/StaticDiscovery.cpp
@@ -838,10 +838,9 @@ void StaticEndpointManager::update_publication_locators(
   LocalPublicationIter iter = local_publications_.find(publicationId);
   if (iter != local_publications_.end()) {
     if (DCPS_debug_level > 3) {
-      const GuidConverter conv(publicationId);
       ACE_DEBUG((LM_INFO,
         ACE_TEXT("(%P|%t) StaticEndpointManager::update_publication_locators - updating locators for %C\n"),
-        OPENDDS_STRING(conv).c_str()));
+        LogGuid(publicationId).c_str()));
     }
     iter->second.trans_info_ = transInfo;
     write_publication_data(publicationId, iter->second);
@@ -925,10 +924,9 @@ void StaticEndpointManager::update_subscription_locators(
   LocalSubscriptionIter iter = local_subscriptions_.find(subscriptionId);
   if (iter != local_subscriptions_.end()) {
     if (DCPS_debug_level > 3) {
-      const GuidConverter conv(subscriptionId);
       ACE_DEBUG((LM_INFO,
         ACE_TEXT("(%P|%t) StaticEndpointManager::update_subscription_locators updating locators for %C\n"),
-        OPENDDS_STRING(conv).c_str()));
+        LogGuid(subscriptionId).c_str()));
     }
     iter->second.trans_info_ = transInfo;
     write_subscription_data(subscriptionId, iter->second);
@@ -1400,8 +1398,8 @@ void StaticEndpointManager::match_continue(const GUID_t& writer, const GUID_t& r
     if (call_writer) {
       if (DCPS_debug_level > 3) {
         ACE_DEBUG((LM_DEBUG, ACE_TEXT("(%P|%t) StaticEndpointManager::match_continue - ")
-          ACE_TEXT("adding writer %C association for reader %C\n"), OPENDDS_STRING(GuidConverter(writer)).c_str(),
-          OPENDDS_STRING(GuidConverter(reader)).c_str()));
+          ACE_TEXT("adding writer %C association for reader %C\n"), LogGuid(writer).c_str(),
+          LogGuid(reader).c_str()));
       }
       DataWriterCallbacks_rch dwr_lock = dwr.lock();
       if (dwr_lock) {
@@ -1421,7 +1419,7 @@ void StaticEndpointManager::match_continue(const GUID_t& writer, const GUID_t& r
       if (DCPS_debug_level > 3) {
         ACE_DEBUG((LM_DEBUG, ACE_TEXT("(%P|%t) StaticEndpointManager::match_continue - ")
           ACE_TEXT("adding reader %C association for writer %C\n"),
-          OPENDDS_STRING(GuidConverter(reader)).c_str(), OPENDDS_STRING(GuidConverter(writer)).c_str()));
+          LogGuid(reader).c_str(), LogGuid(writer).c_str()));
       }
       DataReaderCallbacks_rch drr_lock = drr.lock();
       if (drr_lock) {
@@ -3189,9 +3187,8 @@ void StaticParticipant::remove_discovered_participant(DiscoveredParticipantIter&
     }
 #endif /* DDS_HAS_MINIMUM_BIT */
     if (DCPS_debug_level > 3) {
-      GuidConverter conv(iter->first);
       ACE_DEBUG((LM_INFO, ACE_TEXT("(%P|%t) LocalParticipant::remove_discovered_participant")
-                 ACE_TEXT(" - erasing %C (%B)\n"), OPENDDS_STRING(conv).c_str(), participants_.size()));
+                 ACE_TEXT(" - erasing %C (%B)\n"), LogGuid(iter->first).c_str(), participants_.size()));
     }
 
     remove_discovered_participant_i(iter);

--- a/dds/DCPS/SubscriberImpl.cpp
+++ b/dds/DCPS/SubscriberImpl.cpp
@@ -350,13 +350,12 @@ SubscriberImpl::delete_datareader(::DDS::DataReader_ptr a_datareader)
       }
       if (DCPS_debug_level > 0) {
         RepoId id = dr_servant->get_repo_id();
-        GuidConverter converter(id);
         ACE_ERROR((LM_ERROR,
                   ACE_TEXT("(%P|%t) ERROR: ")
                   ACE_TEXT("SubscriberImpl::delete_datareader: ")
                   ACE_TEXT("datareader(topic_name=%C) %C not found.\n"),
                   topic_name.in(),
-                  OPENDDS_STRING(converter).c_str()));
+                  LogGuid(id).c_str()));
       }
       return ::DDS::RETCODE_ERROR;
     }
@@ -663,11 +662,10 @@ SubscriberImpl::set_qos(
 
           if (!pair.second) {
             if (DCPS_debug_level > 0) {
-              GuidConverter converter(id);
               ACE_ERROR((LM_ERROR,
                         ACE_TEXT("(%P|%t) ERROR: SubscriberImpl::set_qos: ")
                         ACE_TEXT("insert %C to DrIdToQosMap failed.\n"),
-                        OPENDDS_STRING(converter).c_str()));
+                        LogGuid(id).c_str()));
             }
             return ::DDS::RETCODE_ERROR;
           }

--- a/dds/DCPS/WriteDataContainer.cpp
+++ b/dds/DCPS/WriteDataContainer.cpp
@@ -380,16 +380,14 @@ WriteDataContainer::reenqueue_all(const RepoId& reader_id,
   }
 
   if (DCPS_debug_level > 9 && resend_data_.size()) {
-    GuidConverter converter(publication_id_);
-    GuidConverter reader(reader_id);
     ACE_DEBUG((LM_DEBUG,
                ACE_TEXT("(%P|%t) WriteDataContainer::reenqueue_all: ")
                ACE_TEXT("domain %d topic %C publication %C copying ")
                ACE_TEXT("sending/sent to resend to %C.\n"),
                domain_id_,
                topic_name_,
-               OPENDDS_STRING(converter).c_str(),
-               OPENDDS_STRING(reader).c_str()));
+               LogGuid(publication_id_).c_str(),
+               LogGuid(reader_id).c_str()));
   }
 
   return DDS::RETCODE_OK;
@@ -707,13 +705,12 @@ WriteDataContainer::data_delivered(const DataSampleElement* sample)
       if (stale->get_header().message_id_ != SAMPLE_DATA) {
         //this message was a control message so release it
         if (DCPS_debug_level > 9) {
-          GuidConverter converter(publication_id_);
           ACE_DEBUG((LM_DEBUG,
                      ACE_TEXT("(%P|%t) WriteDataContainer::data_delivered: ")
                      ACE_TEXT("domain %d topic %C publication %C control message delivered.\n"),
                      domain_id_,
                      topic_name_,
-                     OPENDDS_STRING(converter).c_str()));
+                     LogGuid(publication_id_).c_str()));
         }
         writer_->controlTracker.message_delivered();
       }
@@ -748,13 +745,12 @@ WriteDataContainer::data_delivered(const DataSampleElement* sample)
   if (stale->get_header().message_id_ != SAMPLE_DATA) {
     //this message was a control message so release it
     if (DCPS_debug_level > 9) {
-      GuidConverter converter(publication_id_);
       ACE_DEBUG((LM_DEBUG,
                  ACE_TEXT("(%P|%t) WriteDataContainer::data_delivered: ")
                  ACE_TEXT("domain %d topic %C publication %C control message delivered.\n"),
                  domain_id_,
                  topic_name_,
-                 OPENDDS_STRING(converter).c_str()));
+                 LogGuid(publication_id_).c_str()));
     }
     release_buffer(stale);
     stale = 0;
@@ -776,13 +772,12 @@ WriteDataContainer::data_delivered(const DataSampleElement* sample)
     }
 
     if (DCPS_debug_level > 9) {
-      GuidConverter converter(publication_id_);
       ACE_DEBUG((LM_DEBUG,
                  ACE_TEXT("(%P|%t) WriteDataContainer::data_delivered: ")
                  ACE_TEXT("domain %d topic %C publication %C seq# %q %s.\n"),
                  domain_id_,
                  topic_name_,
-                 OPENDDS_STRING(converter).c_str(),
+                 LogGuid(publication_id_).c_str(),
                  acked_seq.getValue(),
                  max_durable_per_instance_
                  ? ACE_TEXT("stored for durability")
@@ -905,13 +900,12 @@ WriteDataContainer::data_dropped(const DataSampleElement* sample,
       if (stale->get_header().message_id_ != SAMPLE_DATA) {
         //this message was a control message so release it
         if (DCPS_debug_level > 9) {
-          GuidConverter converter(publication_id_);
           ACE_DEBUG((LM_DEBUG,
                      ACE_TEXT("(%P|%t) WriteDataContainer::data_dropped: ")
                      ACE_TEXT("domain %d topic %C publication %C control message dropped.\n"),
                      domain_id_,
                      topic_name_,
-                     OPENDDS_STRING(converter).c_str()));
+                     LogGuid(publication_id_).c_str()));
         }
         writer_->controlTracker.message_dropped();
       }
@@ -975,12 +969,11 @@ WriteDataContainer::remove_excess_durable()
   }
 
   if (n_released && DCPS_debug_level > 9) {
-    const GuidConverter converter(publication_id_);
     ACE_DEBUG((LM_DEBUG,
                ACE_TEXT("(%P|%t) WriteDataContainer::remove_excess_durable: ")
                ACE_TEXT("domain %d topic %C publication %C %B samples removed ")
                ACE_TEXT("from durable data.\n"), domain_id_, topic_name_,
-               OPENDDS_STRING(converter).c_str(), n_released));
+               LogGuid(publication_id_).c_str(), n_released));
   }
 }
 
@@ -1073,13 +1066,12 @@ WriteDataContainer::remove_oldest_sample(
     released = true;
 
     if (DCPS_debug_level > 9) {
-      GuidConverter converter(publication_id_);
       ACE_DEBUG((LM_DEBUG,
                  ACE_TEXT("(%P|%t) WriteDataContainer::remove_oldest_sample: ")
                  ACE_TEXT("domain %d topic %C publication %C sample removed from HISTORY.\n"),
                  this->domain_id_,
                  this->topic_name_,
-                 OPENDDS_STRING(converter).c_str()));
+                 LogGuid(publication_id_).c_str()));
     }
 
   } else if (containing_list == &this->unsent_data_) {
@@ -1092,13 +1084,12 @@ WriteDataContainer::remove_oldest_sample(
     released = true;
 
     if (DCPS_debug_level > 9) {
-      GuidConverter converter(publication_id_);
       ACE_DEBUG((LM_DEBUG,
                  ACE_TEXT("(%P|%t) WriteDataContainer::remove_oldest_sample: ")
                  ACE_TEXT("domain %d topic %C publication %C sample removed from unsent.\n"),
                  this->domain_id_,
                  this->topic_name_,
-                 OPENDDS_STRING(converter).c_str()));
+                 LogGuid(publication_id_).c_str()));
     }
   } else {
     ACE_ERROR_RETURN((LM_ERROR,


### PR DESCRIPTION
Replaced `OPENDDS_STRING(DCPS::GuidConverter(id))` with calls to LogGuid where it made sense.